### PR TITLE
fix: prisma files presence detection

### DIFF
--- a/assets/languages.json
+++ b/assets/languages.json
@@ -291,7 +291,7 @@
   "regex:\\.ps[md]?1$": "powershell",
   ".ps1xml": "powershell",
   ".prettierignore": "prettier",
-  "prisma.yml": "prisma",
+  ".prisma": "prisma",
   ".pde": "processing",
   ".jade": "pug",
   ".pug": "pug",


### PR DESCRIPTION
Closes #62 

This fix should make `.prisma` files detectable by the extension

But currently I've been facing another issue, when opening a `.prisma` file the LSP does not receive a `textDocument/didOpen` request, even it works fine with another languages. Also if I switched the language while in a Prisma file to to TypeScript for example, presence gets updated fine (to Prisma icon).
