### PR TITLE
fix: correct timestamp conversion from milliseconds to seconds

### DIFF
--- a/lsp/src/discord.rs
+++ b/lsp/src/discord.rs
@@ -124,7 +124,7 @@ impl Discord {
         git_remote_url: Option<String>,
     ) -> Result<()> {
         let mut client = self.get_client().await?;
-        let timestamp: i64 = i64::try_from(self.start_timestamp.as_millis()).map_err(|e| {
+        let timestamp: i64 = i64::try_from(self.start_timestamp.as_secs()).map_err(|e| {
             error!("Failed to convert timestamp: {}", e);
             crate::error::PresenceError::Discord(format!("Failed to convert timestamp: {e}"))
         })?;


### PR DESCRIPTION
  Issue:
  - Line 127: self.start_timestamp.as_millis() was providing milliseconds since Unix epoch
  - Discord's Rich Presence API expects timestamps in seconds since Unix epoch

fixes:
  - Using milliseconds made the timestamp ~1000x too large, causing Discord/Vesktop to reject the activity