### PR TITLE
feat: clear discord activity on LSP shutdown

### DIFF
--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -235,6 +235,17 @@ impl LanguageServer for Backend {
     async fn shutdown(&self) -> Result<()> {
         info!("Shutting down Discord Presence LSP");
 
+        let clear_result = {
+            let mut discord = self.app_state.discord.lock().await;
+            discord.clear_activity().await
+        };
+
+        if let Err(e) = clear_result {
+            error!("Failed to clear Discord activity on shutdown: {}", e);
+        } else {
+            info!("Discord activity cleared on shutdown");
+        }
+
         if let Err(e) = self.presence_service.shutdown().await {
             error!("Failed to shutdown presence service: {}", e);
         } else {


### PR DESCRIPTION
Based on what was said in #98 from @xhyrom "I’m going to try implementing a simpler solution myself by overriding the LSP shutdown method and just calling clear_activity there. That should properly clear the Discord activity when the server shuts down."