### PR TITLE
fix(lsp): prevent stale Discord presence during shutdown and workspace changes

### DIFF
--- a/lsp/src/discord.rs
+++ b/lsp/src/discord.rs
@@ -43,11 +43,12 @@ pub struct Discord {
     client: Option<Mutex<DiscordIpcClient>>,
     start_timestamp: Duration,
     connected: Arc<AtomicBool>,
+    shutting_down: Arc<AtomicBool>,
     last_activity: Option<(ActivityFields, Option<String>)>,
 }
 
 impl Discord {
-    pub fn new() -> Self {
+    pub fn new(shutting_down: Arc<AtomicBool>) -> Self {
         let start_timestamp = SystemTime::now();
         let since_epoch = start_timestamp
             .duration_since(UNIX_EPOCH)
@@ -57,6 +58,7 @@ impl Discord {
             client: None,
             start_timestamp: since_epoch,
             connected: Arc::new(AtomicBool::new(false)),
+            shutting_down,
             last_activity: None,
         }
     }
@@ -64,6 +66,20 @@ impl Discord {
     /// Returns whether the Discord IPC client is currently connected.
     pub fn is_connected(&self) -> bool {
         self.connected.load(Ordering::SeqCst)
+    }
+
+    pub fn has_client(&self) -> bool {
+        self.client.is_some()
+    }
+
+    fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::SeqCst)
+    }
+
+    fn shutdown_error(operation: &str) -> crate::error::PresenceError {
+        crate::error::PresenceError::Discord(format!(
+            "Cannot {operation} while shutdown is in progress"
+        ))
     }
 
     #[instrument(skip(self))]
@@ -82,6 +98,10 @@ impl Discord {
 
     #[instrument(skip(self))]
     pub async fn connect(&self) -> Result<()> {
+        if self.is_shutting_down() {
+            return Err(Self::shutdown_error("connect to Discord IPC"));
+        }
+
         debug!("Connecting to Discord IPC");
 
         let mut client = self.get_client().await?;
@@ -100,6 +120,16 @@ impl Discord {
     /// Will retry up to `MAX_RETRIES` times with increasing delays.
     #[instrument(skip(self))]
     pub async fn connect_with_retry(&self) -> Result<()> {
+        if self.is_shutting_down() {
+            return Err(Self::shutdown_error("connect to Discord IPC"));
+        }
+
+        if !self.has_client() {
+            return Err(crate::error::PresenceError::Discord(
+                "Discord client not initialized".to_string(),
+            ));
+        }
+
         let mut delay = Duration::from_millis(INITIAL_DELAY_MS);
 
         for attempt in 1..=MAX_RETRIES {
@@ -135,6 +165,16 @@ impl Discord {
     /// Attempts to reconnect to Discord, closing any existing connection first.
     #[instrument(skip(self))]
     pub async fn reconnect(&self) -> Result<()> {
+        if self.is_shutting_down() {
+            return Err(Self::shutdown_error("reconnect to Discord IPC"));
+        }
+
+        if !self.has_client() {
+            return Err(crate::error::PresenceError::Discord(
+                "Discord client not initialized".to_string(),
+            ));
+        }
+
         info!("Attempting to reconnect to Discord IPC");
         self.connected.store(false, Ordering::SeqCst);
 
@@ -147,6 +187,11 @@ impl Discord {
     pub async fn kill(&self) -> Result<()> {
         debug!("Killing Discord IPC client");
         self.connected.store(false, Ordering::SeqCst);
+
+        if !self.has_client() {
+            debug!("Skipping Discord IPC close because the client was not initialized");
+            return Ok(());
+        }
 
         let mut client = self.get_client().await?;
         client.close().map_err(|e| {
@@ -170,6 +215,11 @@ impl Discord {
 
         self.last_activity = None;
 
+        if !self.has_client() {
+            debug!("Skipping Discord activity clear because the client was not initialized");
+            return Ok(());
+        }
+
         let mut client = self.get_client().await?;
         client.clear_activity().map_err(|e| {
             error!("Failed to clear activity: {}", e);
@@ -191,6 +241,10 @@ impl Discord {
         activity_fields: ActivityFields,
         git_remote_url: Option<String>,
     ) -> Result<()> {
+        if self.is_shutting_down() {
+            return Err(Self::shutdown_error("update Discord activity"));
+        }
+
         if let Some((last_fields, last_git)) = &self.last_activity {
             if last_fields == &activity_fields && last_git == &git_remote_url {
                 debug!("Activity unchanged, skipping update");
@@ -268,6 +322,11 @@ impl Discord {
         activity_fields: ActivityFields,
         git_remote_url: Option<String>,
     ) -> Result<()> {
+        if self.is_shutting_down() {
+            self.last_activity = None;
+            return Err(Self::shutdown_error("update Discord activity"));
+        }
+
         // If not connected, try to reconnect first
         if !self.is_connected() {
             warn!("Discord not connected, attempting reconnection...");
@@ -296,22 +355,37 @@ impl Discord {
 mod tests {
     use super::*;
 
+    fn shutdown_signal(value: bool) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(value))
+    }
+
+    fn sample_fields() -> ActivityFields {
+        ActivityFields {
+            state: Some("state".to_string()),
+            details: Some("details".to_string()),
+            large_image: None,
+            large_text: None,
+            small_image: None,
+            small_text: None,
+        }
+    }
+
     #[test]
     fn test_discord_new_defaults() {
-        let discord = Discord::new();
+        let discord = Discord::new(shutdown_signal(false));
         assert!(!discord.is_connected());
         assert!(discord.client.is_none());
     }
 
     #[test]
     fn test_is_connected_default_false() {
-        let discord = Discord::new();
+        let discord = Discord::new(shutdown_signal(false));
         assert!(!discord.is_connected());
     }
 
     #[test]
     fn test_connected_state_can_be_changed() {
-        let discord = Discord::new();
+        let discord = Discord::new(shutdown_signal(false));
         assert!(!discord.is_connected());
 
         // Manually set connected to true
@@ -345,8 +419,36 @@ mod tests {
 
     #[test]
     fn test_start_timestamp_is_set() {
-        let discord = Discord::new();
+        let discord = Discord::new(shutdown_signal(false));
         // Timestamp should be non-zero (set to current time)
         assert!(discord.start_timestamp.as_millis() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_connect_with_retry_fails_fast_during_shutdown() {
+        let discord = Discord::new(shutdown_signal(true));
+
+        let error = discord.connect_with_retry().await.unwrap_err();
+
+        assert!(error.to_string().contains("shutdown is in progress"));
+    }
+
+    #[tokio::test]
+    async fn test_clear_activity_without_client_is_noop() {
+        let mut discord = Discord::new(shutdown_signal(false));
+
+        assert!(discord.clear_activity().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_change_activity_with_reconnect_fails_fast_during_shutdown() {
+        let mut discord = Discord::new(shutdown_signal(true));
+
+        let error = discord
+            .change_activity_with_reconnect(sample_fields(), None)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("shutdown is in progress"));
     }
 }

--- a/lsp/src/idle.rs
+++ b/lsp/src/idle.rs
@@ -17,10 +17,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::time;
+use tracing::{debug, warn};
 
 use crate::{
     activity::ActivityManager,
@@ -32,12 +36,22 @@ use crate::{
 #[derive(Debug)]
 pub struct IdleManager {
     handle: Arc<Mutex<Option<JoinHandle<()>>>>,
+    shutting_down: Arc<AtomicBool>,
 }
 
 impl IdleManager {
-    pub fn new() -> Self {
+    pub fn new(shutting_down: Arc<AtomicBool>) -> Self {
         Self {
             handle: Arc::new(Mutex::new(None)),
+            shutting_down,
+        }
+    }
+
+    pub async fn cancel_timeout(&self) {
+        let mut handle_guard = self.handle.lock().await;
+
+        if let Some(handle) = handle_guard.take() {
+            handle.abort();
         }
     }
 
@@ -50,6 +64,12 @@ impl IdleManager {
         last_document: Arc<Mutex<Option<Document>>>,
         workspace: String,
     ) {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            debug!("Skipping idle timeout reset while shutdown is in progress");
+            self.cancel_timeout().await;
+            return;
+        }
+
         let mut handle_guard = self.handle.lock().await;
 
         // Cancel existing timeout
@@ -63,16 +83,25 @@ impl IdleManager {
             config_guard.idle.timeout
         };
 
+        let shutting_down = Arc::clone(&self.shutting_down);
+
         // Spawn new timeout task
         let handle = tokio::spawn(async move {
             time::sleep(timeout_duration).await;
+
+            if shutting_down.load(Ordering::SeqCst) {
+                debug!("Idle timeout fired during shutdown, skipping idle action");
+                return;
+            }
 
             let config_guard = config.lock().await;
             let mut discord_guard = discord.lock().await;
 
             match config_guard.idle.action {
                 IdleAction::ClearActivity => {
-                    let _ = discord_guard.clear_activity().await; // Ignore errors in background task
+                    if let Err(error) = discord_guard.clear_activity().await {
+                        warn!("Failed to clear Discord activity from idle task: {}", error);
+                    }
                 }
                 IdleAction::ChangeActivity => {
                     let doc = last_document.lock().await;
@@ -93,13 +122,74 @@ impl IdleManager {
                         None
                     };
 
-                    let _ = discord_guard
+                    if let Err(error) = discord_guard
                         .change_activity_with_reconnect(activity_fields, git_url)
-                        .await; // Ignore errors in background task
+                        .await
+                    {
+                        warn!(
+                            "Failed to update Discord activity from idle task: {}",
+                            error
+                        );
+                    }
                 }
             }
         });
 
         *handle_guard = Some(handle);
+    }
+
+    #[cfg(test)]
+    pub async fn has_timeout(&self) -> bool {
+        self.handle.lock().await.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::AppState;
+
+    #[tokio::test]
+    async fn test_cancel_timeout_clears_handle() {
+        let state = Arc::new(AppState::new());
+        let idle_manager = IdleManager::new(Arc::clone(&state.shutting_down));
+
+        idle_manager
+            .reset_timeout(
+                Arc::clone(&state.discord),
+                Arc::clone(&state.config),
+                Arc::clone(&state.git_remote_url),
+                Arc::clone(&state.git_branch),
+                Arc::clone(&state.last_document),
+                "workspace".to_string(),
+            )
+            .await;
+
+        assert!(idle_manager.has_timeout().await);
+
+        idle_manager.cancel_timeout().await;
+
+        assert!(!idle_manager.has_timeout().await);
+    }
+
+    #[tokio::test]
+    async fn test_reset_timeout_is_skipped_during_shutdown() {
+        let state = Arc::new(AppState::new());
+        let idle_manager = IdleManager::new(Arc::clone(&state.shutting_down));
+
+        assert!(state.mark_shutting_down());
+
+        idle_manager
+            .reset_timeout(
+                Arc::clone(&state.discord),
+                Arc::clone(&state.config),
+                Arc::clone(&state.git_remote_url),
+                Arc::clone(&state.git_branch),
+                Arc::clone(&state.last_document),
+                "workspace".to_string(),
+            )
+            .await;
+
+        assert!(!idle_manager.has_timeout().await);
     }
 }

--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -235,17 +235,6 @@ impl LanguageServer for Backend {
     async fn shutdown(&self) -> Result<()> {
         info!("Shutting down Discord Presence LSP");
 
-        let clear_result = {
-            let mut discord = self.app_state.discord.lock().await;
-            discord.clear_activity().await
-        };
-
-        if let Err(e) = clear_result {
-            error!("Failed to clear Discord activity on shutdown: {}", e);
-        } else {
-            info!("Discord activity cleared on shutdown");
-        }
-
         if let Err(e) = self.presence_service.shutdown().await {
             error!("Failed to shutdown presence service: {}", e);
         } else {

--- a/lsp/src/service/mod.rs
+++ b/lsp/src/service/mod.rs
@@ -24,7 +24,10 @@ pub use presence_service::PresenceService;
 pub use workspace_service::WorkspaceService;
 
 use crate::{config::Configuration, discord::Discord, document::Document};
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use tokio::sync::Mutex;
 
 #[derive(Debug)]
@@ -35,17 +38,29 @@ pub struct AppState {
     pub git_remote_url: Arc<Mutex<Option<String>>>,
     pub git_branch: Arc<Mutex<Option<String>>>,
     pub last_document: Arc<Mutex<Option<Document>>>,
+    pub shutting_down: Arc<AtomicBool>,
 }
 
 impl AppState {
     pub fn new() -> Self {
+        let shutting_down = Arc::new(AtomicBool::new(false));
+
         Self {
-            discord: Arc::new(Mutex::new(Discord::new())),
+            discord: Arc::new(Mutex::new(Discord::new(Arc::clone(&shutting_down)))),
             config: Arc::new(Mutex::new(Configuration::default())),
             workspace: Arc::new(Mutex::new(WorkspaceService::new())),
             git_remote_url: Arc::new(Mutex::new(None)),
             git_branch: Arc::new(Mutex::new(None)),
             last_document: Arc::new(Mutex::new(None)),
+            shutting_down,
         }
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::SeqCst)
+    }
+
+    pub fn mark_shutting_down(&self) -> bool {
+        !self.shutting_down.swap(true, Ordering::SeqCst)
     }
 }

--- a/lsp/src/service/presence_service.rs
+++ b/lsp/src/service/presence_service.rs
@@ -22,6 +22,7 @@ use crate::{
     service::AppState,
 };
 use std::sync::Arc;
+use tracing::{debug, warn};
 
 #[derive(Debug)]
 pub struct PresenceService {
@@ -31,13 +32,20 @@ pub struct PresenceService {
 
 impl PresenceService {
     pub fn new(state: Arc<AppState>) -> Self {
+        let idle_manager = IdleManager::new(Arc::clone(&state.shutting_down));
+
         Self {
             state,
-            idle_manager: IdleManager::new(),
+            idle_manager,
         }
     }
 
     pub async fn update_presence(&self, doc: Option<Document>) -> Result<()> {
+        if self.state.is_shutting_down() {
+            debug!("Skipping presence update because shutdown is in progress");
+            return Ok(());
+        }
+
         // Store the last document for idle use
         {
             let mut last_doc = self.state.last_document.lock().await;
@@ -47,6 +55,11 @@ impl PresenceService {
         // Reset idle timeout if document changed
         if doc.is_some() {
             self.reset_idle_timeout().await?;
+        }
+
+        if self.state.is_shutting_down() {
+            debug!("Skipping Discord activity update because shutdown started mid-update");
+            return Ok(());
         }
 
         // Build and set activity
@@ -59,6 +72,11 @@ impl PresenceService {
     }
 
     pub async fn initialize_discord(&self, application_id: &str) -> Result<()> {
+        if self.state.is_shutting_down() {
+            debug!("Skipping Discord initialization because shutdown is in progress");
+            return Ok(());
+        }
+
         let mut discord = self.state.discord.lock().await;
         discord.create_client(application_id)?;
         discord.connect_with_retry().await?;
@@ -66,8 +84,36 @@ impl PresenceService {
     }
 
     pub async fn shutdown(&self) -> Result<()> {
-        let discord = self.state.discord.lock().await;
-        discord.kill().await?;
+        if !self.state.mark_shutting_down() {
+            debug!("Presence service shutdown already in progress");
+            self.idle_manager.cancel_timeout().await;
+            return Ok(());
+        }
+
+        self.idle_manager.cancel_timeout().await;
+
+        let mut discord = self.state.discord.lock().await;
+        let mut first_error = None;
+
+        if let Err(error) = discord.clear_activity().await {
+            warn!(
+                "Failed to clear Discord activity during shutdown: {}",
+                error
+            );
+            first_error = Some(error);
+        }
+
+        if let Err(error) = discord.kill().await {
+            warn!("Failed to close Discord IPC during shutdown: {}", error);
+            if first_error.is_none() {
+                first_error = Some(error);
+            }
+        }
+
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+
         Ok(())
     }
 
@@ -103,6 +149,11 @@ impl PresenceService {
         activity_fields: crate::activity::ActivityFields,
         git_url: Option<String>,
     ) -> Result<()> {
+        if self.state.is_shutting_down() {
+            debug!("Skipping Discord activity update because shutdown is in progress");
+            return Ok(());
+        }
+
         let mut discord = self.state.discord.lock().await;
 
         discord
@@ -113,6 +164,11 @@ impl PresenceService {
     }
 
     async fn reset_idle_timeout(&self) -> Result<()> {
+        if self.state.is_shutting_down() {
+            debug!("Skipping idle timeout reset because shutdown is in progress");
+            return Ok(());
+        }
+
         let workspace_name = {
             let workspace = self.state.workspace.lock().await;
             workspace.name().to_string()
@@ -129,5 +185,45 @@ impl PresenceService {
             .await;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_shutdown_cancels_idle_timeout_and_marks_state() {
+        let state = Arc::new(AppState::new());
+        let service = PresenceService::new(Arc::clone(&state));
+
+        service.reset_idle_timeout().await.unwrap();
+        assert!(service.idle_manager.has_timeout().await);
+
+        service.shutdown().await.unwrap();
+
+        assert!(state.is_shutting_down());
+        assert!(!service.idle_manager.has_timeout().await);
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_is_idempotent() {
+        let state = Arc::new(AppState::new());
+        let service = PresenceService::new(state);
+
+        assert!(service.shutdown().await.is_ok());
+        assert!(service.shutdown().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_update_presence_is_ignored_during_shutdown() {
+        let state = Arc::new(AppState::new());
+        let service = PresenceService::new(Arc::clone(&state));
+
+        assert!(state.mark_shutting_down());
+        assert!(service.update_presence(None).await.is_ok());
+
+        let last_document = state.last_document.lock().await;
+        assert!(last_document.is_none());
     }
 }


### PR DESCRIPTION
## Summary

This refactors the LSP-side Discord presence lifecycle to prevent stale presence from surviving Zed shutdowns, idle transitions, and workspace changes.

The core fix is to coordinate shutdown, idle timers, and reconnect logic through one shared lifecycle state, instead of letting detached idle work continue after teardown begins and refactored my old implmentation.

Fixes #97

## Root cause

The existing shutdown flow cleared Discord activity when the LSP received `shutdown`, but idle work could still be running in the background.

That created a race where:
- shutdown cleared activity
- the pending idle task fired anyway
- `change_activity_with_reconnect()` reconnected and re-published presence
- Discord kept showing stale activity after Zed exited or after switching workspaces

## What changed

### Shared shutdown lifecycle state
- added a shared `shutting_down` flag to `AppState`
- passed that lifecycle state into the Discord wrapper and idle manager

### Idle task management
- made idle timers explicitly cancellable via `cancel_timeout()`
- skipped scheduling new idle timers while shutdown is in progress
- skipped idle actions if the timer fires after shutdown has started
- replaced silent background-task error swallowing with warnings

### Discord lifecycle guards
- prevented `connect`, `connect_with_retry`, `reconnect`, `change_activity`, and `change_activity_with_reconnect` from running during shutdown
- made `clear_activity()` and `kill()` safe no-ops when the client was never initialized
- made reconnect fail fast when no client exists instead of retrying pointlessly

### Presence service teardown
- moved shutdown ownership into `PresenceService`
- shutdown now:
  - marks shutdown once
  - cancels idle work first
  - clears Discord activity
  - closes the IPC client
  - stays idempotent on repeated calls
- suppressed new presence updates and idle resets once shutdown begins

### Backend cleanup
- simplified `Backend::shutdown()` to delegate to the service-owned shutdown path

## Tests

Added regression coverage for the lifecycle edges that caused the bug:

- idle timeout cancellation clears the handle
- idle reset is skipped during shutdown
- reconnect fails fast during shutdown
- updating activity during shutdown fails fast
- shutdown cancels pending idle work and marks state
- shutdown is idempotent
- presence updates are ignored during shutdown

## Verification

### Automated
- `cargo test --workspace`

Result:
- 33 passed
- 0 failed

### Manual
Validated in Zed using the updated local LSP:
- closing Zed now clears presence correctly
- switching workspaces no longer leaves the old workspace activity stuck
- updated LSP behavior was confirmed against the local build