### PR TITLE
Update extension version to include recent fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-discord-presence"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license-file = "LICENSE"
 repository = "https://github.com/xhyrom/zed-discord-presence"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "discord-presence"
 name = "Discord Presence"
-version = "0.2.4"
+version = "0.2.5"
 schema_version = 1
 authors = ["Jozef Steinhübl <contact@xhyrom.dev>"]
 description = "Presence for your beautiful discord account :)"


### PR DESCRIPTION
This updates the published extension version to include recent fixes and improvements from the past month.
It includes the fix for Discord presence not updating when closing Zed, which is currently missing from the latest released version (0.2.4).

Current workaround is to install the extension locally to get the fix.