### PR TITLE
feat: resolve workspace display name from .zed/settings.json

### DIFF
--- a/lsp/src/activity/mod.rs
+++ b/lsp/src/activity/mod.rs
@@ -24,6 +24,20 @@ use crate::{
     config::Configuration, document::Document, languages::get_language, util::Placeholders,
 };
 
+fn resolve_workspace(workspace: &str) -> String {
+    std::fs::read_to_string(std::path::Path::new(workspace).join(".zed/settings.json"))
+        .ok()
+        .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+        .and_then(|json| json["project_name"].as_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| {
+            std::path::Path::new(workspace)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(workspace)
+                .to_string()
+        })
+}
+
 #[derive(Debug, Clone)]
 pub struct ActivityManager;
 
@@ -34,15 +48,14 @@ impl ActivityManager {
         workspace: &str,
         git_branch: Option<String>,
     ) -> ActivityFields {
-        let placeholders = Placeholders::new(doc, config, workspace, git_branch);
-
+        let workspace = resolve_workspace(workspace);
+        let placeholders = Placeholders::new(doc, config, &workspace, git_branch);
         let activity = if let Some(doc) = doc {
             let language = get_language(doc).to_lowercase();
             config.languages.get(&language).unwrap_or(&config.activity)
         } else {
             &config.activity
         };
-
         ActivityFields::from(activity).resolve_placeholders(&placeholders)
     }
 
@@ -52,8 +65,8 @@ impl ActivityManager {
         workspace: &str,
         git_branch: Option<String>,
     ) -> ActivityFields {
-        let placeholders = Placeholders::new(doc, config, workspace, git_branch);
-
+        let workspace = resolve_workspace(workspace);
+        let placeholders = Placeholders::new(doc, config, &workspace, git_branch);
         ActivityFields::from(&config.idle.activity).resolve_placeholders(&placeholders)
     }
 }

--- a/lsp/src/service/presence_service.rs
+++ b/lsp/src/service/presence_service.rs
@@ -128,7 +128,7 @@ impl PresenceService {
         Ok(ActivityManager::build_activity_fields(
             doc,
             &config,
-            workspace.name(),
+            workspace.path().unwrap_or_else(|| workspace.name()),
             git_branch,
         ))
     }
@@ -169,9 +169,12 @@ impl PresenceService {
             return Ok(());
         }
 
-        let workspace_name = {
+        let workspace_path = {
             let workspace = self.state.workspace.lock().await;
-            workspace.name().to_string()
+            workspace
+                .path()
+                .unwrap_or_else(|| workspace.name())
+                .to_string()
         };
         self.idle_manager
             .reset_timeout(
@@ -180,7 +183,7 @@ impl PresenceService {
                 Arc::clone(&self.state.git_remote_url),
                 Arc::clone(&self.state.git_branch),
                 Arc::clone(&self.state.last_document),
-                workspace_name,
+                workspace_path,
             )
             .await;
 


### PR DESCRIPTION
Read `project_name` from the workspaces `.zed/settings` and use it verbatim as the `{workspace}` placeholder. Falls back to the workspace directory name when unset.

There was no way to customize the workspace name shown in Discord without renaming the directory. A project named `my-cool app` would always appear as `my-cool-app` regardless of how I wanted it displayed (My Cool App).